### PR TITLE
Fix connection leak by reusing RoundTripper.

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,5 +1,7 @@
 package sabnzbd
 
+import "net/http"
+
 type Option func(*Sabnzbd) error
 
 func UseHttp() Option {
@@ -58,5 +60,11 @@ func ApikeyAuth(apikey string) Option {
 func NoneAuth() Option {
 	return func(s *Sabnzbd) error {
 		return s.setAuth(noneAuth{})
+	}
+}
+
+func UseRoundTripper(rt http.RoundTripper) Option {
+	return func(s *Sabnzbd) error {
+		return s.setRoundTripper(rt)
 	}
 }


### PR DESCRIPTION
By default use same RoundTripper for all calls. Allow setting of
RoundTripper via Option to Sabnzbd.New.

Example of leak: https://play.golang.org/p/8WMZvrUk9O